### PR TITLE
Fix bot responding to other bots

### DIFF
--- a/source/handle_messages.py
+++ b/source/handle_messages.py
@@ -16,8 +16,11 @@ class Listeners(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message: discord.message.Message) -> None:
         """Listen to messages sent to chat."""
-        if message.author == self.bot.user:
+        if message.author.bot:
             return
 
         if message.content.startswith("Marco"):
             await message.channel.send("Polo!")
+
+        if message.content == "Polo!":
+            await message.channel.send("Cockta!")


### PR DESCRIPTION
Current implementation makes the Herald ignore only messages sent by itself. This fix should make it ignore all bot messages.

I tried adding a unit test for this case, but I couldn't make the dpytest library mock out a bot user that would send messages - it might be possible, but it seems way too complex for this particular problem.

So instead, I added a second clause that can cause a chain reaction when there are two bots talking to each other. The updated bot will not react to Harold's "Polo!", but it will respond if a user types so.