### PR TITLE
Streamline CI and replace Flake8 with Ruff

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -36,13 +36,13 @@ jobs:
         run: isort ./source ./tests --check
 
       - name: Check requirements order
-        run: sort-requirements ./tests/test_requirements.txt --check
+        run: sort-requirements ./tests/test_requirements.txt requirements.txt --check
 
-      - name: Run flake8
-        run: flake8 ./source ./tests
+      - name: Run Ruff
+        run: ruff .
 
       - name: Run MyPy
-        run: mypy ./source ./tests
+        run: mypy ./source
 
 
   unit_tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,9 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
+    -   id: requirements-txt-fixer
     -   id: check-yaml
+    -   id: check-toml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
@@ -13,7 +15,8 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.290
     hooks:
-      - id: flake8
+    -   id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [tool.mypy]
+ignore_missing_imports = true
 exclude = [
     "^venv",
+    "tests/*"
     ]
+
 [tool.pytest.ini_options]
 pythonpath = [
     "source",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,17 @@ select = [
 ]
 ignore = [
     "ANN101",   # "Missing type annotation for 'self' in method"
-    "D203",     # "Required one blank line before class docstrings (incompatible with D211)"
+    "D203",     # "Required one blank line before class docstrings" (incompatible with D211)
     "D213",     # "Required initial triple quotes to be on separate line for multiline docstrings."
+    "S105",     # "Possible hardcoded password assigned" (too many false positives)
 ]
 fixable = ["ALL"]
 line-length = 88
 format = "grouped"
+
+[tool.ruff.per-file-ignores]
+"tests/*" = [
+    "S101",     # "Use of assert detected" (should be allowed in tests)
+    "ANN001",   # "Missing type annotation for function argument" (fixtures' types are often complex, not worth it)
+    "ANN201",   # "Missing return type annotation for function" (tests will always return None, there's no point)
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,21 @@ exclude = [
 pythonpath = [
     "source",
 ]
+
+[tool.ruff]
+include = [     # What directories are to be checked
+    "source/*.py",
+    "tests/*.py",
+    "**/pyproject.toml",
+]
+select = [
+    "ALL"   # Use all possible rules
+]
+ignore = [
+    "ANN101",   # "Missing type annotation for 'self' in method"
+    "D203",     # "Required one blank line before class docstrings (incompatible with D211)"
+    "D213",     # "Required initial triple quotes to be on separate line for multiline docstrings."
+]
+fixable = ["ALL"]
+line-length = 88
+format = "grouped"

--- a/source/__init__.py
+++ b/source/__init__.py
@@ -1,0 +1,1 @@
+"""Init file of the source directory."""

--- a/source/handle_messages.py
+++ b/source/handle_messages.py
@@ -11,6 +11,7 @@ class Listeners(commands.Cog):
     """Class for regular messages."""
 
     def __init__(self, bot: commands.Bot) -> None:
+        """Initialize the Listeners class."""
         self.bot = bot
 
     @commands.Cog.listener()

--- a/source/main.py
+++ b/source/main.py
@@ -11,7 +11,8 @@ def get_token() -> str:
     """Find and return proper Discord authorization token."""
     token = os.getenv("DISCORD_TOKEN")
     if not token:
-        raise KeyError("Not able to find Discord credentials")
+        msg = "Not able to find Discord credentials"
+        raise KeyError(msg)
     return token
 
 

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -36,6 +36,7 @@ pytest==7.2.1
 pytest-mock==3.10.0
 pytest_asyncio==0.21.0
 python-dotenv==1.0.0
+ruff==0.0.290
 snowballstemmer==2.2.0
 sort-requirements==1.3.0
 tomli==2.0.1

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -11,10 +11,6 @@ discord==2.1.0
 discord.py==2.2.3
 dpytest==0.6.6
 exceptiongroup==1.1.0
-flake8==6.0.0
-flake8-annotations==3.0.1
-flake8-bugbear==23.5.9
-flake8-docstrings==1.7.0
 frozenlist==1.3.3
 idna==3.4
 iniconfig==2.0.0
@@ -25,13 +21,9 @@ mypy==1.3.0
 mypy-extensions==1.0.0
 packaging==23.0
 pathspec==0.11.1
-pep8-naming==0.13.3
 platformdirs==3.5.1
 pluggy==1.0.0
 pre-commit==3.3.1
-pycodestyle==2.10.0
-pydocstyle==6.3.0
-pyflakes==3.0.1
 pytest==7.2.1
 pytest-mock==3.10.0
 pytest_asyncio==0.21.0

--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Init file of the unit_tests directory."""

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,15 +2,15 @@
 import os
 
 import discord
-import discord.ext.commands as commands
 import discord.ext.test as dpytest
 import pytest
 import pytest_asyncio
+from discord.ext import commands
 from handle_messages import Listeners
 
 
 @pytest.fixture()
-def set_environment_variable():
+def _set_environment_variable() -> None:
     """Create a token environment variable for testing.
 
     After the test is finished (pass or fail), delete the variable.
@@ -23,13 +23,13 @@ def set_environment_variable():
 
 
 @pytest_asyncio.fixture()
-async def fake_bot():
+async def fake_bot() -> commands.Bot:
     """Create a fake bot for command testing."""
     intents = discord.Intents.default()
     intents.members = True
     intents.message_content = True
     bot = commands.Bot(command_prefix="!", intents=intents)
-    await bot._async_setup_hook()
+    await bot._async_setup_hook()  # noqa: SLF001 (ignore accessing private method)
     await bot.add_cog(Listeners(bot))
     dpytest.configure(bot)
 

--- a/tests/unit_tests/test_handle_messages.py
+++ b/tests/unit_tests/test_handle_messages.py
@@ -3,8 +3,9 @@ import discord.ext.test as dpytest
 import pytest
 
 
-@pytest.mark.asyncio
-async def test_marco(fake_bot):
-    """Assert that sending Marco returns Polo!"""
+@pytest.mark.usefixtures("fake_bot")
+@pytest.mark.asyncio()
+async def test_marco():
+    """Assert that sending 'Marco' returns 'Polo!'."""
     await dpytest.message("Marco")
     assert dpytest.verify().message().content("Polo!")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1,24 +1,25 @@
 """File containing all unit tests for main.py file."""
 import pytest
 from main import get_token, run_service
+from pytest_mock import MockerFixture
 
 
 class TestGetToken:
     """A class for all get_token related tests."""
 
-    def test_get_proper_token(self, set_environment_variable) -> None:
+    @pytest.mark.usefixtures("_set_environment_variable")
+    def test_get_proper_token(self) -> None:
         """Check if get_token properly returns the token from environment."""
         assert get_token() == "Test_token"
 
     def test_error_when_token_missing(self) -> None:
-        """Check if the function properly raises KeyError when
-        there is no DISCORD_TOKEN key in the environment.
-        """
+        """Check if the function properly raises KeyError without the proper token."""
         with pytest.raises(KeyError):
             get_token()
 
 
-def test_run_service(mocker, set_environment_variable) -> None:
+@pytest.mark.usefixtures("_set_environment_variable")
+def test_run_service(mocker: MockerFixture) -> None:
     """Assert that bot.run is being properly called.
 
     To achieve that, make the load_dotenv() function and


### PR DESCRIPTION
This PR drops usage of Flake8, which is often slow and hard to configure, and adds Ruff instead.

I made it use all of the extensions it has, so, admittedly, there were quite a few errors raised which needed a quick fix.
I suggest taking a look before creating a new branch, as this will almost surely cause merge conflicts in your changes.